### PR TITLE
Add configurations for security metadata namespace

### DIFF
--- a/config/sample.cfg
+++ b/config/sample.cfg
@@ -92,6 +92,14 @@ WRRMedium = 2   # Low-priority command will inserted after two medium-priority c
 # Each namespace has same capacity
 DefaultNamespace = 1
 
+## Security Namespace
+# Specify number of security namespaces to create
+SecurityNamespace = 1
+
+## Security Metadata Ratio
+# Specify the ratio of security namespace size from the total logical size
+SecurityMetadataRatio = 0.2
+
 ## LBA Size
 # Set logical block size of default namespace
 # If DefaultNamespace is false, this value will ignored

--- a/ftl/page_mapping.hh
+++ b/ftl/page_mapping.hh
@@ -33,6 +33,19 @@ namespace SimpleSSD {
 
 namespace FTL {
 
+typedef struct _SecurityMetadata {
+  // TODO: Synchronize with MerkleTree code
+  void *node;
+} SecurityMetadata;
+
+typedef struct _RecoveryEntry {
+  // SSD Info
+  std::vector<Block> garbageBlocks;
+
+  // MerkleTree metadata
+  std::list<SecurityMetadata> innerNodes;
+} RecoveryEntry;
+
 class PageMapping : public AbstractFTL {
  private:
   PAL::PAL *pPAL;
@@ -51,6 +64,8 @@ class PageMapping : public AbstractFTL {
   bool bReclaimMore;
   bool bRandomTweak;
   uint32_t bitsetSize;
+
+  std::vector<RecoveryEntry> recoveryTable;
 
   struct {
     uint64_t gcCount;

--- a/hil/nvme/config.cc
+++ b/hil/nvme/config.cc
@@ -40,6 +40,8 @@ const char NAME_MAX_IO_SQUEUE[] = "MaxIOSQueue";
 const char NAME_WRR_HIGH[] = "WRRHigh";
 const char NAME_WRR_MEDIUM[] = "WRRMedium";
 const char NAME_ENABLE_DEFAULT_NAMESPACE[] = "DefaultNamespace";
+const char NAME_ENABLE_SECURITY_NAMESPACE[] = "SecurityNamespace";
+const char NAME_SECURITY_METADATA_RATIO[] = "SecurityMetadataRatio";
 const char NAME_LBA_SIZE[] = "LBASize";
 const char NAME_ENABLE_DISK_IMAGE[] = "EnableDiskImage";
 const char NAME_STRICT_DISK_SIZE[] = "StrictSizeCheck";
@@ -60,6 +62,8 @@ Config::Config() {
   wrrMedium = 2;
   lbaSize = 512;
   defaultNamespace = 1;
+  securityNamespace = 1;
+  securityMetadataRatio = 0.2;
   enableDiskImage = false;
   strictDiskSize = false;
   useCopyOnWriteDisk = false;
@@ -138,6 +142,12 @@ bool Config::setConfig(const char *name, const char *value) {
   }
   else if (MATCH_NAME(NAME_ENABLE_DEFAULT_NAMESPACE)) {
     defaultNamespace = (uint16_t)strtoul(value, nullptr, 10);
+  }
+  else if (MATCH_NAME(NAME_ENABLE_SECURITY_NAMESPACE)) {
+    securityNamespace = (uint16_t)strtoul(value, nullptr, 10);
+  }
+  else if (MATCH_NAME(NAME_SECURITY_METADATA_RATIO)) {
+    securityMetadataRatio = strtof(value, nullptr);
   }
   else if (MATCH_NAME(NAME_LBA_SIZE)) {
     lbaSize = strtoul(value, nullptr, 10);
@@ -235,8 +245,23 @@ uint64_t Config::readUint(uint32_t idx) {
     case NVME_ENABLE_DEFAULT_NAMESPACE:
       ret = defaultNamespace;
       break;
+    case NVME_ENABLE_SECURITY_NAMESPACE:
+      ret = securityNamespace;
+      break;
     case NVME_LBA_SIZE:
       ret = lbaSize;
+      break;
+  }
+
+  return ret;
+}
+
+float Config::readFloat(uint32_t idx) {
+  float ret = 0;
+
+  switch (idx) {
+    case NVME_SECURITY_METADATA_RATIO:
+      ret = securityMetadataRatio;
       break;
   }
 

--- a/hil/nvme/config.hh
+++ b/hil/nvme/config.hh
@@ -46,6 +46,8 @@ typedef enum {
   NVME_WRR_HIGH,
   NVME_WRR_MEDIUM,
   NVME_ENABLE_DEFAULT_NAMESPACE,
+  NVME_ENABLE_SECURITY_NAMESPACE,
+  NVME_SECURITY_METADATA_RATIO,
   NVME_LBA_SIZE,
   NVME_ENABLE_DISK_IMAGE,
   NVME_STRICT_DISK_SIZE,
@@ -68,6 +70,8 @@ class Config : public BaseConfig {
   uint16_t wrrMedium;            //!< Default: 2
   uint64_t lbaSize;              //!< Default: 512
   uint16_t defaultNamespace;     //!< Default: 1
+  uint16_t securityNamespace;     //!< Default: 1
+  float securityMetadataRatio;     //!< Default: 0.2
   bool enableDiskImage;          //!< Default: False
   bool strictDiskSize;           //!< Default: False
   bool useCopyOnWriteDisk;       //!< Default: False
@@ -81,6 +85,7 @@ class Config : public BaseConfig {
 
   int64_t readInt(uint32_t) override;
   uint64_t readUint(uint32_t) override;
+  float readFloat(uint32_t) override;
   std::string readString(uint32_t) override;
   bool readBoolean(uint32_t) override;
 };

--- a/hil/nvme/controller.cc
+++ b/hil/nvme/controller.cc
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "hil/nvme/interface.hh"
 #include "hil/nvme/ocssd.hh"

--- a/hil/nvme/dma.cc
+++ b/hil/nvme/dma.cc
@@ -129,7 +129,7 @@ void PRPList::getPRPListFromPRP(uint64_t base, uint64_t size) {
     DMAInitContext *pContext = (DMAInitContext *)context;
     PRPList *pThis = (PRPList *)pContext->pThis;
     uint64_t listPRP;
-    uint64_t listPRPSize;
+    uint64_t listPRPSize = 0;
     uint64_t currentSize = 0;
 
     pThis->callCounter--;


### PR DESCRIPTION
- Enable setting the number and the size of the namespace for
  security metadata from sample.cfg